### PR TITLE
Add offline town killer name

### DIFF
--- a/maps/wasteland/player.lua
+++ b/maps/wasteland/player.lua
@@ -82,7 +82,13 @@ function Public.requests(player)
                 i.clear()
             end
 
-            player.print("Your town has fallen since you last played. Good luck next time!", {r = 1, g = 0, b = 0})
+            if this.killer_name[player.index] then
+                player.print("Your town has fallen to " .. this.killer_name[player.index] .. " since you last played!", {r = 1, g = 0, b = 0})
+                this.killer_name[player.index] = nil
+            else
+                player.print("Your town has fallen since you last played!", {r = 1, g = 0, b = 0})
+            end
+
             player.character.die()
         end
         this.requests[player.index] = nil

--- a/maps/wasteland/table.lua
+++ b/maps/wasteland/table.lua
@@ -16,6 +16,7 @@ Global.register(
 function Public.reset_table()
     this.rocket_launches = {}
     this.requests = {}
+    this.killer_name = {}
     this.town_centers = {}
     this.cooldowns_town_placement = {}
     this.last_respawn = {}

--- a/maps/wasteland/team.lua
+++ b/maps/wasteland/team.lua
@@ -716,6 +716,16 @@ local function kill_force(force_name, cause)
         if player.character then
             player.character.die()
         elseif not player.connected then
+            this.killer_name[player.index] = 'unknown'
+            if is_suicide then
+                this.killer_name[player.index] = 'suicide'
+            else
+                if cause.force.name ~= 'enemy' then
+                    this.killer_name[player.index] = cause.player.name
+                else
+                    this.killer_name[player.index] = 'biters'
+                end
+            end
             this.requests[player.index] = 'kill-character'
         end
         Public.set_player_to_outlander(player)

--- a/maps/wasteland/team.lua
+++ b/maps/wasteland/team.lua
@@ -721,7 +721,9 @@ local function kill_force(force_name, cause)
                 this.killer_name[player.index] = 'suicide'
             else
                 if cause.force.name ~= 'enemy' then
-                    this.killer_name[player.index] = cause.player.name
+                    if cause.player.name ~= nil then
+                        this.killer_name[player.index] = cause.player.name
+                    end
                 else
                     this.killer_name[player.index] = 'biters'
                 end


### PR DESCRIPTION
Add town killer name information when a town falls and a player is offline.
Needs to be tested in real server situation first.