### PR TITLE
Allow ore veins without "Steel axe" technology

### DIFF
--- a/maps/wasteland/rocks_yield_ore_veins.lua
+++ b/maps/wasteland/rocks_yield_ore_veins.lua
@@ -193,9 +193,6 @@ local function on_player_mined_entity(event)
     if math_random(1, this.rocks_yield_ore_veins.chance) ~= 1 and not this.testing_mode then
         return
     end
-    if player.force.technologies['steel-axe'].researched == false then
-        return
-    end
     ore_vein(event)
     if this.tutorials[player.index] then
         this.tutorials[player.index].mined_rock = true


### PR DESCRIPTION
It doesn't really change anything except it's easy to use for players, and they are not going to waste rocks anymore.
(It's better to have it, than mine rocks to waste time and make maps even harder)