### PR TITLE
Disable utils.freeplay.lua

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -37,7 +37,7 @@ require 'utils.gui.group'
 require 'utils.gui.score'
 require 'utils.gui.config'
 require 'utils.gui.poll'
-require 'utils.freeplay'
+-- require 'utils.freeplay'
 
 require 'maps.wasteland.main'
 


### PR DESCRIPTION
There's point of using it for "wasteland" scenario.
And it resolves the problem with indestructible players when they spawn the first time.